### PR TITLE
Validate images build without pushing on PR

### DIFF
--- a/.github/workflows/php74.yml
+++ b/.github/workflows/php74.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
     paths:
+      - .github/workflows/php74.yml
+      - '7.4-dev/**'
+  pull_request:
+    paths:
+      - .github/workflows/php74.yml
       - '7.4-dev/**'
   schedule:
     - cron: '0 0 1,15 * *'
@@ -40,7 +45,7 @@ jobs:
         with:
           context: 7.4-dev/${{ matrix.alpine }}/${{ matrix.sapi }}
           no-cache: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             phpdaily/php:7.4-${{ matrix.sapi }}-${{ matrix.alpine }}
             ${{ env.tag_generic_version }}
@@ -73,7 +78,7 @@ jobs:
         with:
           context: 7.4-dev/${{ matrix.ubuntu }}/${{ matrix.sapi }}
           no-cache: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             phpdaily/php:7.4-${{ matrix.sapi }}-${{ matrix.ubuntu }}
             ${{ env.tag_generic_platform }}

--- a/.github/workflows/php74.yml
+++ b/.github/workflows/php74.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event_name != 'pull_request'
       - run: |
           echo "tag_generic_version=phpdaily/php:7.4" >> $GITHUB_ENV
           echo "tag_short_platform=phpdaily/php:7.4-alpine" >> $GITHUB_ENV
@@ -71,6 +72,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event_name != 'pull_request'
       - run: echo "tag_generic_platform=phpdaily/php:7.4-${{ matrix.ubuntu }}" >> $GITHUB_ENV
         if: ${{ matrix.sapi == 'cli' }}
       - name: Build

--- a/.github/workflows/php80.yml
+++ b/.github/workflows/php80.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
     paths:
+      - .github/workflows/php80.yml
+      - '8.0-dev/**'
+  pull_request:
+    paths:
+      - .github/workflows/php80.yml
       - '8.0-dev/**'
   schedule:
     - cron: '0 0 * * *'
@@ -40,7 +45,7 @@ jobs:
         with:
           context: 8.0-dev/${{ matrix.alpine }}/${{ matrix.sapi }}
           no-cache: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             phpdaily/php:8.0-${{ matrix.sapi }}-${{ matrix.alpine }}
             ${{ env.tag_generic_version }}
@@ -73,7 +78,7 @@ jobs:
         with:
           context: 8.0-dev/${{ matrix.ubuntu }}/${{ matrix.sapi }}
           no-cache: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             phpdaily/php:8.0-${{ matrix.sapi }}-${{ matrix.ubuntu }}
             ${{ env.tag_generic_platform }}

--- a/.github/workflows/php80.yml
+++ b/.github/workflows/php80.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event_name != 'pull_request'
       - run: |
           echo "tag_generic_version=phpdaily/php:8.0" >> $GITHUB_ENV
           echo "tag_short_platform=phpdaily/php:8.0-alpine" >> $GITHUB_ENV
@@ -71,6 +72,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event_name != 'pull_request'
       - run: echo "tag_generic_platform=phpdaily/php:8.0-${{ matrix.ubuntu }}" >> $GITHUB_ENV
         if: ${{ matrix.sapi == 'cli' }}
       - name: Build

--- a/.github/workflows/php81.yml
+++ b/.github/workflows/php81.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
     paths:
+      - .github/workflows/php81.yml
+      - '8.1-dev/**'
+  pull_request:
+    paths:
+      - .github/workflows/php81.yml
       - '8.1-dev/**'
   schedule:
     - cron: '0 0 * * *'
@@ -41,7 +46,7 @@ jobs:
         with:
           context: 8.1-dev/${{ matrix.alpine }}/${{ matrix.sapi }}
           no-cache: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             phpdaily/php:8.1-${{ matrix.sapi }}-${{ matrix.alpine }}
             ${{ env.tag_latest }}
@@ -75,7 +80,7 @@ jobs:
         with:
           context: 8.1-dev/${{ matrix.ubuntu }}/${{ matrix.sapi }}
           no-cache: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             phpdaily/php:8.1-${{ matrix.sapi }}-${{ matrix.ubuntu }}
             ${{ env.tag_generic_platform }}

--- a/.github/workflows/php81.yml
+++ b/.github/workflows/php81.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event_name != 'pull_request'
       - run: |
           echo "tag_latest=phpdaily/php:latest" >> $GITHUB_ENV
           echo "tag_generic_version=phpdaily/php:8.1" >> $GITHUB_ENV
@@ -73,6 +74,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event_name != 'pull_request'
       - run: echo "tag_generic_platform=phpdaily/php:8.1-${{ matrix.ubuntu }}" >> $GITHUB_ENV
         if: ${{ matrix.sapi == 'cli' }}
       - name: Build

--- a/.github/workflows/php82.yml
+++ b/.github/workflows/php82.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event_name != 'pull_request'
       - run: |
           echo "tag_generic_version=phpdaily/php:8.2" >> $GITHUB_ENV
           echo "tag_short_platform=phpdaily/php:8.2-alpine" >> $GITHUB_ENV
@@ -71,6 +72,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event_name != 'pull_request'
       - run: echo "tag_generic_platform=phpdaily/php:8.2-${{ matrix.ubuntu }}" >> $GITHUB_ENV
         if: ${{ matrix.sapi == 'cli' }}
       - name: Build

--- a/.github/workflows/php82.yml
+++ b/.github/workflows/php82.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
     paths:
+      - .github/workflows/php82.yml
+      - '8.2-dev/**'
+  pull_request:
+    paths:
+      - .github/workflows/php82.yml
       - '8.2-dev/**'
   schedule:
     - cron: '0 0 * * *'
@@ -40,7 +45,7 @@ jobs:
         with:
           context: 8.2-dev/${{ matrix.alpine }}/${{ matrix.sapi }}
           no-cache: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             phpdaily/php:8.2-${{ matrix.sapi }}-${{ matrix.alpine }}
             ${{ env.tag_generic_version }}
@@ -73,7 +78,7 @@ jobs:
         with:
           context: 8.2-dev/${{ matrix.ubuntu }}/${{ matrix.sapi }}
           no-cache: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             phpdaily/php:8.2-${{ matrix.sapi }}-${{ matrix.ubuntu }}
             ${{ env.tag_generic_platform }}


### PR DESCRIPTION
With this proposal, images build would be done when a PR is opened, in order to be able to validate that proposed changes are not breaking images build.

Workflow would also be trigerred when corresponding workflow configuration file would be changed.